### PR TITLE
Preserve quotes on returned raw content

### DIFF
--- a/kiota_serialization_json/json_parse_node_factory.py
+++ b/kiota_serialization_json/json_parse_node_factory.py
@@ -35,5 +35,5 @@ class JsonParseNodeFactory(ParseNodeFactory):
             raise TypeError("Content cannot be null")
 
         content_as_str = content.decode('utf-8')
-        content_dict = json.loads(content_as_str)
+        content_dict = json.loads(json.dumps(content_as_str))
         return JsonParseNode(content_dict)

--- a/tests/unit/test_json_parse_node_factory.py
+++ b/tests/unit/test_json_parse_node_factory.py
@@ -17,7 +17,7 @@ def test_get_root_parse_node(sample_json_string):
     sample_json_string_bytes = sample_json_string.encode('utf-8')
     root = factory.get_root_parse_node('application/json', sample_json_string_bytes)
     assert isinstance(root, JsonParseNode)
-
+    assert str(root.get_bytes_value(), "utf-8") == sample_json_string
 
 def test_get_root_parse_node_no_content_type(sample_json_string):
     with pytest.raises(Exception) as e_info:


### PR DESCRIPTION
The bug can be easily reproduced with the provided unit test (i.e. without applying the fix).
The test is going to fail with the following output:

```
E       assert "{'name': 'Te...: 'New York'}" == '{"name":"Tes...":"New York"}'
E         - {"name":"Tesla", "age":2, "city":"New York"}
E         + {'name': 'Tesla', 'age': 2, 'city': 'New York'}
```

As you can see the original double-quotes are not preserved but are substituted with single-quotes.
I don't know if there are more efficient ways to achieve the same result, but this solves the underlying issues