### PR TITLE
Bugfix/deserialization of enum collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug with deserializing collection of enum values.
+
+## [0.3.2] - 2023-04-27
+
+### Added
+
+### Changed
+
 - Fixed a bug with deserializing models with additional data.
 
 ## [0.3.1] - 2023-03-20

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -142,8 +142,16 @@
                 "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
                 "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.1.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.6"
         },
         "coverage": {
             "extras": [
@@ -210,16 +218,24 @@
                 "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
                 "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
             ],
-            "markers": "python_version >= '3.11'",
+            "markers": "python_version < '3.11'",
             "version": "==0.3.6"
         },
         "docutils": {
             "hashes": [
-                "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
-                "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
+                "sha256:a428f10de4de4774389734c986a01b4af2d802d26717108b0f1b9356862937c5",
+                "sha256:f75a5a52fbcacd81b47e42888ad2b380748aaccfb3f13af0fe69deb759f01eb6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.19"
+            "version": "==0.20"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
+                "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.1"
         },
         "flit": {
             "hashes": [
@@ -420,7 +436,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
         "tomli-w": {
@@ -541,7 +557,7 @@
                 "sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559",
                 "sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"
             ],
-            "markers": "python_version >= '3.11'",
+            "markers": "python_version < '3.11'",
             "version": "==1.15.0"
         },
         "yapf": {

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.3.2'
+VERSION: str = '0.3.3'

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -194,9 +194,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         enum_collection = self._json_node
         if not enum_collection:
             return []
-        return list(
-            map(lambda x: JsonParseNode(x).get_enum_value(enum_class), enum_collection)
-        )
+        return list(map(lambda x: JsonParseNode(x).get_enum_value(enum_class), enum_collection))
 
     def get_enum_value(self, enum_class: K) -> Optional[K]:
         """Gets the enum value of the node

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -176,10 +176,13 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         Returns:
             List[U]: The collection of model object values of the node
         """
+        object_collection = self._json_node
+        if not object_collection:
+            return []
         return list(
             map(
                 lambda x: JsonParseNode(x).get_object_value(factory),  # type: ignore
-                self._json_node
+                object_collection
             )
         )
 
@@ -188,12 +191,11 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         Returns:
             List[K]: The collection of enum values
         """
-        raw_values = self.get_str_value()
-        if not raw_values:
+        enum_collection = self._json_node
+        if not enum_collection:
             return []
-
         return list(
-            map(lambda x: JsonParseNode(x).get_enum_value(enum_class), raw_values.split(","))
+            map(lambda x: JsonParseNode(x).get_enum_value(enum_class), enum_collection)
         )
 
     def get_enum_value(self, enum_class: K) -> Optional[K]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+-i https://pypi.org/simple
+
+microsoft-kiota-abstractions==0.5.1
+
+python-dateutil==2.8.2
+
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+
+uritemplate==4.1.1 ; python_version >= '3.6'
+

--- a/tests/unit/test_json_parse_node.py
+++ b/tests/unit/test_json_parse_node.py
@@ -144,7 +144,7 @@ def test_get_bytes_value():
 
 
 def test_get_collection_of_enum_values():
-    parse_node = JsonParseNode("dunhill,oval")
+    parse_node = JsonParseNode(["dunhill","oval"])
     result = parse_node.get_collection_of_enum_values(OfficeLocation)
     assert isinstance(result, list)
     assert result == [OfficeLocation.Dunhill, OfficeLocation.Oval]


### PR DESCRIPTION
This PR Fixes #80 by passing enum collections as a python list instead of string.

Related to https://github.com/microsoftgraph/msgraph-sdk-python/pull/196
 