### PR TITLE
handle str in object_dict

### DIFF
--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -278,6 +278,9 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         # if object is null
         if not object_dict:
             return
+        
+        if isinstance(object_dict, str):
+            object_dict = json.loads(object_dict)
 
         if isinstance(item, AdditionalDataHolder):
             item_additional_data = item.additional_data

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -278,7 +278,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         # if object is null
         if not object_dict:
             return
-        
+
         if isinstance(object_dict, str):
             object_dict = json.loads(object_dict)
 


### PR DESCRIPTION
Hi, thanks for  kiota-serialization-json-python,
currently running following code snippet, using: https://github.com/microsoftgraph/msgraph-sdk-python#3-make-requests-against-the-service

```python
credential = ClientSecretCredential(*self._client_secret_credential())
scopes = ["https://graph.microsoft.com/.default"]
auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
request_adapter = GraphRequestAdapter(auth_provider)
client = GraphServiceClient(request_adapter)

async def get_user(result_obj: _Result):
    try:
        user = await client.users.by_user_id("userPrincipalName").get()
        result_obj.result = user
    except APIError as e:
        result_obj.result = e.error.message
```

would throw:
```python
Traceback (most recent call last):
  File "*****", line 52, in get_user
    user = await client.users.by_user_id("userPrincipalName").get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "*****/Library/Application Support/hatch/env/virtual/microsoftgraph/ChLKhk30/microsoftgraph/lib/python3.11/site-packages/msgraph/generated/users/item/user_item_request_builder.py", line 162, in get
    return await self.request_adapter.send_async(request_info, user.User, error_mapping)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "*****/Library/Application Support/hatch/env/virtual/microsoftgraph/ChLKhk30/microsoftgraph/lib/python3.11/site-packages/kiota_http/httpx_request_adapter.py", line 118, in send_async
    await self.throw_failed_responses(response, error_map)
  File "*****/Library/Application Support/hatch/env/virtual/microsoftgraph/ChLKhk30/microsoftgraph/lib/python3.11/site-packages/kiota_http/httpx_request_adapter.py", line 310, in throw_failed_responses
    error = root_node.get_object_value(error_class)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "*****/Library/Application Support/hatch/env/virtual/microsoftgraph/ChLKhk30/microsoftgraph/lib/python3.11/site-packages/kiota_serialization_json/json_parse_node.py", line 227, in get_object_value
    self._assign_field_values(result)
  File "*****/Library/Application Support/hatch/env/virtual/microsoftgraph/ChLKhk30/microsoftgraph/lib/python3.11/site-packages/kiota_serialization_json/json_parse_node.py", line 290, in _assign_field_values
    for key, val in object_dict.items():
                    ^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'items'

```

because object_dict is str:
```python
'{  "error": {    "code": "Request_ResourceNotFound",    "message": "Resource 'userPrincipalName' does not exist or one of its queried reference-property objects are not present.",    "innerError": {      "date": "2023-05-17T08:18:22",      "request-id": "*****",      "client-request-id": "******"    }  }}'
```

And the code change resolve it.

Maybe related: https://github.com/microsoft/kiota-serialization-json-python/issues/83
