### PR TITLE
Fix key assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2023-07-04
+
+### Added
+
+### Changed
+- Fixes the key assignment to the writer in write_bytes_value.
+
 ## [0.3.6] - 2023-06-27
 
 ### Added

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.3.6'
+VERSION: str = '0.3.7'

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -208,7 +208,7 @@ class JsonSerializationWriter(SerializationWriter):
             base64_bytes = base64.b64encode(value)
             base64_string = base64_bytes.decode('utf-8')
             if key:
-                self.writer['key'] = base64_string
+                self.writer[key] = base64_string
             else:
                 self.value = base64_string
 


### PR DESCRIPTION
Fixes self.writer key assignment in write_bytes_value


The method write_bytes_value contained an assignment error where the key was accessed as a string instead of using the variable directly. This commit fixes the issue by updating the assignment to use the variable directly as the key.