### PR TITLE
Bugfix/serialize models initialized with args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2023-09-14
+
+### Added
+
+### Changed
+- Fixed a bug where BackedModel attributes initialized with arguments were not added to serialized content.
+
 ## [0.4.0] - 2023-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2023-09-14
+## [0.4.1] - 2023-09-14
 
 ### Added
 

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.4.0'
+VERSION: str = '0.4.1'

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.4.1'
+VERSION: str = '0.5.0'

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.5.0'
+VERSION: str = '0.4.1'

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -409,14 +409,8 @@ class JsonSerializationWriter(SerializationWriter):
         if on_start := self.on_start_object_serialization:
             on_start(value, self)
         value.serialize(temp_writer)
-        if isinstance(value, BackedModel):
-            changed_keys = [k for k, v in value.backing_store.enumerate_()]
-            serialized_keys = list(temp_writer.writer)
-            for key in list(set(serialized_keys) - set(changed_keys)):
-                # Discard unchanged values from serialization
-                del temp_writer.writer[key]
 
-    def _create_new_writer(self) -> SerializationWriter:
+    def _create_new_writer(self) -> JsonSerializationWriter:
         writer = JsonSerializationWriter()
         writer.on_before_object_serialization = self.on_before_object_serialization
         writer.on_after_object_serialization = self.on_after_object_serialization

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -411,7 +411,7 @@ class JsonSerializationWriter(SerializationWriter):
         value.serialize(temp_writer)
         if isinstance(value, BackedModel):
             changed_keys = [k for k, v in value.backing_store.enumerate_()]
-            serialized_keys = [k for k in temp_writer.writer]
+            serialized_keys = list(temp_writer.writer)
             for key in list(set(serialized_keys) - set(changed_keys)):
                 # Discard unchanged values from serialization
                 del temp_writer.writer[key]

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -410,7 +410,7 @@ class JsonSerializationWriter(SerializationWriter):
             on_start(value, self)
         value.serialize(temp_writer)
         if isinstance(value, BackedModel):
-            changed_keys = [k for k,v in value.backing_store.enumerate_()]
+            changed_keys = [k for k, v in value.backing_store.enumerate_()]
             serialized_keys = [k for k in temp_writer.writer]
             for key in list(set(serialized_keys) - set(changed_keys)):
                 # Discard unchanged values from serialization

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -280,6 +280,7 @@ class JsonSerializationWriter(SerializationWriter):
         """
         if self.writer and self.value:
             if isinstance(self.value, dict):
+                # Adds values changed to null to writer to get final serialized content
                 self.writer.update(self.value)
                 self.value = None
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "microsoft-kiota-serialization-json"
 authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 dependencies = [
-    "microsoft-kiota_abstractions >=0.1.0",
+    "microsoft-kiota_abstractions >=0.8,<0.9",
     "python-dateutil >=2.8.2",
 ]
 license = {file = "LICENSE"}


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota-abstractions-python/pull/138

Ensures BackedModel attributes initialized using arguments are marked as changed and added to serialized content.