### PR TITLE
Bugfix/allow strings datetime UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2023-09-21
+
+### Added
+
+### Changed
+- Allow passing of valid strings as values for datetime and UUID fields.
+
 ## [0.4.0] - 2023-07-27
 
 ### Added

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.4.0'
+VERSION: str = '0.4.1'

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -95,7 +95,7 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid UUID string value found for property {key}")  
+                    raise ValueError(f"Invalid UUID string value found for property {key}")
                 raise ValueError("Invalid UUID string value found")
 
     def write_datetime_value(self, key: Optional[str], value: Optional[datetime]) -> None:
@@ -118,7 +118,7 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid datetime string value found for property {key}")  
+                    raise ValueError(f"Invalid datetime string value found for property {key}")
                 raise ValueError("Invalid datetime string value found")
 
     def write_timedelta_value(self, key: Optional[str], value: Optional[timedelta]) -> None:
@@ -141,7 +141,7 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid timedelta string value found for property {key}")  
+                    raise ValueError(f"Invalid timedelta string value found for property {key}")
                 raise ValueError("Invalid timedelta string value found")
 
     def write_date_value(self, key: Optional[str], value: Optional[date]) -> None:
@@ -164,7 +164,7 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid date string value found for property {key}")  
+                    raise ValueError(f"Invalid date string value found for property {key}")
                 raise ValueError("Invalid date string value found")
 
     def write_time_value(self, key: Optional[str], value: Optional[time]) -> None:
@@ -187,7 +187,7 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid time string value found for property {key}")  
+                    raise ValueError(f"Invalid time string value found for property {key}")
                 raise ValueError("Invalid time string value found")
 
     def write_collection_of_primitive_values(

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 from uuid import UUID
 
+from dateutil import parser
 from kiota_abstractions.serialization import Parsable, SerializationWriter
 
 T = TypeVar("T")
@@ -85,6 +86,17 @@ class JsonSerializationWriter(SerializationWriter):
                 self.writer[key] = str(value)
             else:
                 self.value = str(value)
+        elif isinstance(value, str):
+            try:
+                UUID(value)
+                if key:
+                    self.writer[key] = value
+                else:
+                    self.value = value
+            except ValueError:
+                if key:
+                  raise ValueError(f"Invalid UUID value found for property {key}")  
+                raise ValueError("Invalid UUID value found")
 
     def write_datetime_value(self, key: Optional[str], value: Optional[datetime]) -> None:
         """Writes the specified datetime offset value to the stream with an optional given key.
@@ -97,6 +109,17 @@ class JsonSerializationWriter(SerializationWriter):
                 self.writer[key] = str(value.isoformat())
             else:
                 self.value = str(value.isoformat())
+        elif isinstance(value, str):
+            try:
+                parser.parse(value)
+                if key:
+                    self.writer[key] = value
+                else:
+                    self.value = value
+            except ValueError:
+                if key:
+                  raise ValueError(f"Invalid datetime value found for property {key}")  
+                raise ValueError("Invalid datetime value found")
 
     def write_timedelta_value(self, key: Optional[str], value: Optional[timedelta]) -> None:
         """Writes the specified timedelta value to the stream with an optional given key.
@@ -109,6 +132,17 @@ class JsonSerializationWriter(SerializationWriter):
                 self.writer[key] = str(value)
             else:
                 self.value = str(value)
+        elif isinstance(value, str):
+            try:
+                parser.parse(value)
+                if key:
+                    self.writer[key] = value
+                else:
+                    self.value = value
+            except ValueError:
+                if key:
+                  raise ValueError(f"Invalid timedelta value found for property {key}")  
+                raise ValueError("Invalid timedelta value found")
 
     def write_date_value(self, key: Optional[str], value: Optional[date]) -> None:
         """Writes the specified date value to the stream with an optional given key.
@@ -121,6 +155,17 @@ class JsonSerializationWriter(SerializationWriter):
                 self.writer[key] = str(value)
             else:
                 self.value = str(value)
+        elif isinstance(value, str):
+            try:
+                parser.parse(value)
+                if key:
+                    self.writer[key] = value
+                else:
+                    self.value = value
+            except ValueError:
+                if key:
+                  raise ValueError(f"Invalid date value found for property {key}")  
+                raise ValueError("Invalid date value found")
 
     def write_time_value(self, key: Optional[str], value: Optional[time]) -> None:
         """Writes the specified time value to the stream with an optional given key.
@@ -133,6 +178,17 @@ class JsonSerializationWriter(SerializationWriter):
                 self.writer[key] = str(value)
             else:
                 self.value = str(value)
+        elif isinstance(value, str):
+            try:
+                parser.parse(value)
+                if key:
+                    self.writer[key] = value
+                else:
+                    self.value = value
+            except ValueError:
+                if key:
+                  raise ValueError(f"Invalid time value found for property {key}")  
+                raise ValueError("Invalid time value found")
 
     def write_collection_of_primitive_values(
         self, key: Optional[str], values: Optional[List[T]]
@@ -402,6 +458,7 @@ class JsonSerializationWriter(SerializationWriter):
             on_before(value)
         if on_start := self.on_start_object_serialization:
             on_start(value, self)
+
         value.serialize(temp_writer)
 
     def _create_new_writer(self) -> SerializationWriter:

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -95,8 +95,8 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid UUID value found for property {key}")  
-                raise ValueError("Invalid UUID value found")
+                  raise ValueError(f"Invalid UUID string value found for property {key}")  
+                raise ValueError("Invalid UUID string value found")
 
     def write_datetime_value(self, key: Optional[str], value: Optional[datetime]) -> None:
         """Writes the specified datetime offset value to the stream with an optional given key.
@@ -118,8 +118,8 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid datetime value found for property {key}")  
-                raise ValueError("Invalid datetime value found")
+                  raise ValueError(f"Invalid datetime string value found for property {key}")  
+                raise ValueError("Invalid datetime string value found")
 
     def write_timedelta_value(self, key: Optional[str], value: Optional[timedelta]) -> None:
         """Writes the specified timedelta value to the stream with an optional given key.
@@ -141,8 +141,8 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid timedelta value found for property {key}")  
-                raise ValueError("Invalid timedelta value found")
+                  raise ValueError(f"Invalid timedelta string value found for property {key}")  
+                raise ValueError("Invalid timedelta string value found")
 
     def write_date_value(self, key: Optional[str], value: Optional[date]) -> None:
         """Writes the specified date value to the stream with an optional given key.
@@ -164,8 +164,8 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid date value found for property {key}")  
-                raise ValueError("Invalid date value found")
+                  raise ValueError(f"Invalid date string value found for property {key}")  
+                raise ValueError("Invalid date string value found")
 
     def write_time_value(self, key: Optional[str], value: Optional[time]) -> None:
         """Writes the specified time value to the stream with an optional given key.
@@ -187,8 +187,8 @@ class JsonSerializationWriter(SerializationWriter):
                     self.value = value
             except ValueError:
                 if key:
-                  raise ValueError(f"Invalid time value found for property {key}")  
-                raise ValueError("Invalid time value found")
+                  raise ValueError(f"Invalid time string value found for property {key}")  
+                raise ValueError("Invalid time string value found")
 
     def write_collection_of_primitive_values(
         self, key: Optional[str], values: Optional[List[T]]

--- a/tests/unit/test_json_serialization_writer.py
+++ b/tests/unit/test_json_serialization_writer.py
@@ -71,8 +71,20 @@ def test_write_uuid_value():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"id": "8f841f30-e6e3-439a-a812-ebd369559c36"}'
-
-
+    
+def test_write_uuid_value_with_valid_string():
+    json_serialization_writer = JsonSerializationWriter()
+    json_serialization_writer.write_uuid_value("id", "8f841f30-e6e3-439a-a812-ebd369559c36")
+    content = json_serialization_writer.get_serialized_content()
+    content_string = content.decode('utf-8')
+    assert content_string == '{"id": "8f841f30-e6e3-439a-a812-ebd369559c36"}'
+    
+def test_write_uuid_value_with_invalid_string():
+    with pytest.raises(ValueError) as excinfo:
+        json_serialization_writer = JsonSerializationWriter()
+        json_serialization_writer.write_uuid_value("id", "invalid-uuid-string")
+    assert "Invalid UUID string value found for property id" in str(excinfo.value)
+    
 def test_write_datetime_value():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_datetime_value(
@@ -81,7 +93,23 @@ def test_write_datetime_value():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117"}'
-
+    
+def test_write_datetime_value_valid_string():
+    json_serialization_writer = JsonSerializationWriter()
+    json_serialization_writer.write_datetime_value(
+        "updatedAt", "2022-01-27T12:59:45.596117"
+    )
+    content = json_serialization_writer.get_serialized_content()
+    content_string = content.decode('utf-8')
+    assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117"}'
+    
+def test_write_datetime_value_valid_string():
+    with pytest.raises(ValueError) as excinfo:
+        json_serialization_writer = JsonSerializationWriter()
+        json_serialization_writer.write_datetime_value(
+            "updatedAt", "invalid-datetime-string"
+        )
+    assert "Invalid datetime string value found for property updatedAt" in str(excinfo.value)
 
 def test_write_timedelta_value():
     json_serialization_writer = JsonSerializationWriter()
@@ -92,7 +120,26 @@ def test_write_timedelta_value():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"diff": "2:00:00"}'
-
+    
+def test_write_timedelta_value_valid_string():
+    json_serialization_writer = JsonSerializationWriter()
+    json_serialization_writer.write_timedelta_value(
+        "diff",
+        "2:00:00"
+    )
+    content = json_serialization_writer.get_serialized_content()
+    content_string = content.decode('utf-8')
+    assert content_string == '{"diff": "2:00:00"}'
+    
+def test_write_timedelta_value_invalid_string():
+    with pytest.raises(ValueError) as excinfo:
+        json_serialization_writer = JsonSerializationWriter()
+        json_serialization_writer.write_timedelta_value(
+            "diff",
+            "invalid-timedelta-string"
+        )
+    assert "Invalid timedelta string value found for property diff" in str(excinfo.value)
+    
 
 def test_write_date_value():
     json_serialization_writer = JsonSerializationWriter()
@@ -101,6 +148,18 @@ def test_write_date_value():
     content_string = content.decode('utf-8')
     assert content_string == '{"birthday": "2000-09-04"}'
 
+def test_write_date_value_valid_string():
+    json_serialization_writer = JsonSerializationWriter()
+    json_serialization_writer.write_date_value("birthday", "2000-09-04")
+    content = json_serialization_writer.get_serialized_content()
+    content_string = content.decode('utf-8')
+    assert content_string == '{"birthday": "2000-09-04"}'
+    
+def test_write_date_value_invalid_string():
+    with pytest.raises(ValueError) as excinfo:
+        json_serialization_writer = JsonSerializationWriter()
+        json_serialization_writer.write_date_value("birthday", "invalid-date-string")
+    assert "Invalid date string value found for property birthday" in str(excinfo.value)
 
 def test_write_time_value():
     json_serialization_writer = JsonSerializationWriter()
@@ -112,6 +171,24 @@ def test_write_time_value():
     content_string = content.decode('utf-8')
     assert content_string == '{"time": "12:59:45.596117"}'
 
+def test_write_time_value_valid_string():
+    json_serialization_writer = JsonSerializationWriter()
+    json_serialization_writer.write_time_value(
+        "time",
+        "12:59:45.596117"
+    )
+    content = json_serialization_writer.get_serialized_content()
+    content_string = content.decode('utf-8')
+    assert content_string == '{"time": "12:59:45.596117"}'
+    
+def test_write_time_value_invalid_string():
+    with pytest.raises(ValueError) as excinfo:
+        json_serialization_writer = JsonSerializationWriter()
+        json_serialization_writer.write_time_value(
+            "time",
+            "invalid-time-string"
+        )
+    assert "Invalid time string value found for property time" in str(excinfo.value)
 
 def test_write_collection_of_primitive_values():
     json_serialization_writer = JsonSerializationWriter()


### PR DESCRIPTION
Allows valid strings as values for `datetime` and `UUID` fields.

Fixes: https://github.com/microsoftgraph/msgraph-sdk-python/issues/330