### PR TITLE
Chore/dateutil to pendulum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2023-10-11
+
+### Added
+
+### Changed
+- Switched from python-dateutil to pendulum for parsing datetime types.
+
 ## [0.4.1] - 2023-09-21
 
 ### Added

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.5.0'
+VERSION: str = '0.4.2'

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.4.1'
+VERSION: str = '0.5.0'

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 from uuid import UUID
 
-from dateutil import parser
+import pendulum
 from kiota_abstractions.serialization import Parsable, ParsableFactory, ParseNode
 
 T = TypeVar("T")
@@ -90,7 +90,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, datetime):
             return self._json_node
         if isinstance(self._json_node, str):
-            return parser.parse(self._json_node)
+            return pendulum.parse(self._json_node)
         return None
 
     def get_timedelta_value(self) -> Optional[timedelta]:
@@ -101,7 +101,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, timedelta):
             return self._json_node
         if isinstance(self._json_node, str):
-            datetime_obj = parser.parse(self._json_node)
+            datetime_obj = pendulum.parse(self._json_node)
             return timedelta(
                 hours=datetime_obj.hour, minutes=datetime_obj.minute, seconds=datetime_obj.second
             )
@@ -115,7 +115,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, date):
             return self._json_node
         if isinstance(self._json_node, str):
-            datetime_obj = parser.parse(self._json_node)
+            datetime_obj = pendulum.parse(self._json_node)
             return datetime_obj.date()
         return None
 
@@ -127,7 +127,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, time):
             return self._json_node
         if isinstance(self._json_node, str):
-            datetime_obj = parser.parse(self._json_node)
+            datetime_obj = pendulum.parse(self._json_node)
             return datetime_obj.time()
         return None
 
@@ -293,7 +293,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
             return dict(map(lambda x: (x[0], self.try_get_anything(x[1])), value.items()))
         if isinstance(value, str):
             try:
-                datetime_obj = parser.parse(value)
+                datetime_obj = pendulum.parse(value)
                 return timedelta(
                     hours=datetime_obj.hour,
                     minutes=datetime_obj.minute,
@@ -302,7 +302,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
             except ValueError:
                 pass
             try:
-                return parser.parse(value)
+                return pendulum.parse(value)
             except ValueError:
                 pass
             try:

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -90,7 +90,9 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, datetime):
             return self._json_node
         if isinstance(self._json_node, str):
-            return pendulum.parse(self._json_node)
+            datetime_obj = pendulum.parse(self._json_node, exact=True)
+            if isinstance(datetime_obj, pendulum.DateTime):
+                return datetime_obj
         return None
 
     def get_timedelta_value(self) -> Optional[timedelta]:
@@ -101,10 +103,9 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, timedelta):
             return self._json_node
         if isinstance(self._json_node, str):
-            datetime_obj = pendulum.parse(self._json_node)
-            return timedelta(
-                hours=datetime_obj.hour, minutes=datetime_obj.minute, seconds=datetime_obj.second
-            )
+            datetime_obj = pendulum.parse(self._json_node, exact=True)
+            if isinstance(datetime_obj, pendulum.Duration):
+                return datetime_obj.as_timedelta()
         return None
 
     def get_date_value(self) -> Optional[date]:
@@ -115,8 +116,9 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, date):
             return self._json_node
         if isinstance(self._json_node, str):
-            datetime_obj = pendulum.parse(self._json_node)
-            return datetime_obj.date()
+            datetime_obj = pendulum.parse(self._json_node, exact=True)
+            if isinstance(datetime_obj, pendulum.Date):
+                return datetime_obj
         return None
 
     def get_time_value(self) -> Optional[time]:
@@ -127,8 +129,9 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(self._json_node, time):
             return self._json_node
         if isinstance(self._json_node, str):
-            datetime_obj = pendulum.parse(self._json_node)
-            return datetime_obj.time()
+            datetime_obj = pendulum.parse(self._json_node, exact=True)
+            if isinstance(datetime_obj, pendulum.Time):
+                return datetime_obj
         return None
 
     def get_collection_of_primitive_values(self, primitive_type: Any) -> Optional[List[T]]:
@@ -294,15 +297,9 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         if isinstance(value, str):
             try:
                 datetime_obj = pendulum.parse(value)
-                return timedelta(
-                    hours=datetime_obj.hour,
-                    minutes=datetime_obj.minute,
-                    seconds=datetime_obj.second
-                )
-            except ValueError:
-                pass
-            try:
-                return pendulum.parse(value)
+                if isinstance(datetime_obj, pendulum.Duration):
+                    return datetime_obj.as_timedelta()
+                return datetime_obj
             except ValueError:
                 pass
             try:

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 from uuid import UUID
 
-from dateutil import parser
+import pendulum
 from kiota_abstractions.serialization import Parsable, SerializationWriter
 
 T = TypeVar("T")
@@ -111,7 +111,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = str(value.isoformat())
         elif isinstance(value, str):
             try:
-                parser.parse(value)
+                pendulum.parse(value)
                 if key:
                     self.writer[key] = value
                 else:
@@ -134,7 +134,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = str(value)
         elif isinstance(value, str):
             try:
-                parser.parse(value)
+                pendulum.parse(value)
                 if key:
                     self.writer[key] = value
                 else:
@@ -157,7 +157,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = str(value)
         elif isinstance(value, str):
             try:
-                parser.parse(value)
+                pendulum.parse(value)
                 if key:
                     self.writer[key] = value
                 else:
@@ -180,7 +180,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = str(value)
         elif isinstance(value, str):
             try:
-                parser.parse(value)
+                pendulum.parse(value)
                 if key:
                     self.writer[key] = value
                 else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "microsoft-kiota-serialization-json"
 authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 dependencies = [
     "microsoft-kiota_abstractions >=0.1.0",
-    "python-dateutil >=2.8.2",
+    "pendulum >=2.1.2",
 ]
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,7 +70,7 @@ exceptiongroup==1.1.3
 
 microsoft-kiota-abstractions==0.8.7
 
-python-dateutil==2.8.2
+pendulum==2.1.2
 
 six==1.16.0
 

--- a/tests/unit/test_json_parse_node.py
+++ b/tests/unit/test_json_parse_node.py
@@ -48,24 +48,24 @@ def test_get_datetime_value():
 
 
 def test_get_date_value():
-    parse_node = JsonParseNode('2015-04-20T11:50:51Z')
+    parse_node = JsonParseNode('2015-04-20')
     result = parse_node.get_date_value()
     assert isinstance(result, date)
     assert str(result) == '2015-04-20'
 
 
 def test_get_time_value():
-    parse_node = JsonParseNode('2022-01-27T12:59:45.596117')
+    parse_node = JsonParseNode('12:59:45.596117')
     result = parse_node.get_time_value()
     assert isinstance(result, time)
     assert str(result) == '12:59:45.596117'
 
 
 def test_get_timedelta_value():
-    parse_node = JsonParseNode('2022-01-27T12:59:45.596117')
+    parse_node = JsonParseNode('PT30S')
     result = parse_node.get_timedelta_value()
     assert isinstance(result, timedelta)
-    assert str(result) == '12:59:45'
+    assert str(result) == '0:00:30'
 
 
 def test_get_collection_of_primitive_values():

--- a/tests/unit/test_json_serialization_writer.py
+++ b/tests/unit/test_json_serialization_writer.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
 import pytest
-from dateutil import parser
 
+import pendulum
 from kiota_serialization_json.json_serialization_writer import JsonSerializationWriter
 
 from ..helpers import OfficeLocation, User, User2
@@ -11,7 +11,7 @@ from ..helpers import OfficeLocation, User, User2
 @pytest.fixture
 def user_1():
     user = User()
-    user.updated_at = parser.parse("2022-01-27T12:59:45.596117")
+    user.updated_at = pendulum.parse("2022-01-27T12:59:45.596117")
     user.is_active = True
     user.id = UUID("8f841f30-e6e3-439a-a812-ebd369559c36")
     return user
@@ -88,11 +88,11 @@ def test_write_uuid_value_with_invalid_string():
 def test_write_datetime_value():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_datetime_value(
-        "updatedAt", parser.parse('2022-01-27T12:59:45.596117')
+        "updatedAt", pendulum.parse('2022-01-27T12:59:45.596117')
     )
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
-    assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117"}'
+    assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117+00:00"}'
     
 def test_write_datetime_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
@@ -101,7 +101,7 @@ def test_write_datetime_value_valid_string():
     )
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
-    assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117"}'
+    assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117+00:00"}'
     
 def test_write_datetime_value_valid_string():
     with pytest.raises(ValueError) as excinfo:
@@ -115,7 +115,7 @@ def test_write_timedelta_value():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_timedelta_value(
         "diff",
-        parser.parse('2022-01-27T12:59:45.596117') - parser.parse('2022-01-27T10:59:45.596117')
+        (pendulum.parse('2022-01-27T12:59:45.596117') - pendulum.parse('2022-01-27T10:59:45.596117')).as_timedelta()
     )
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
@@ -143,7 +143,7 @@ def test_write_timedelta_value_invalid_string():
 
 def test_write_date_value():
     json_serialization_writer = JsonSerializationWriter()
-    json_serialization_writer.write_date_value("birthday", parser.parse("2000-09-04").date())
+    json_serialization_writer.write_date_value("birthday", pendulum.parse("2000-09-04").date())
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"birthday": "2000-09-04"}'
@@ -165,7 +165,7 @@ def test_write_time_value():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_time_value(
         "time",
-        parser.parse('2022-01-27T12:59:45.596117').time()
+        pendulum.parse('2022-01-27T12:59:45.596117').time()
     )
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
@@ -206,7 +206,7 @@ def test_write_collection_of_object_values(user_1, user_2):
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"users": [{"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
-        '"updated_at": "2022-01-27T12:59:45.596117", "is_active": true}, '\
+        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '\
         '{"display_name": "John Doe", "age": 32}]}'
 
 
@@ -226,7 +226,7 @@ def test_write_object_value(user_1):
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"user1": {"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
-        '"updated_at": "2022-01-27T12:59:45.596117", "is_active": true}}'
+        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}}'
 
 
 def test_write_enum_value():

--- a/tests/unit/test_union_wrapper.py
+++ b/tests/unit/test_union_wrapper.py
@@ -32,7 +32,7 @@ class TestUnionWrapperParseTests:
         assert result.composed_type1.id == UUID("8f841f30-e6e3-439a-a812-ebd369559c36")
         assert result.composed_type1.office_location == OfficeLocation.Dunhill
         assert result.composed_type1.is_active is True
-        assert str(result.composed_type1.updated_at) == '2021-07-29 03:07:25+00:00'
+        assert str(result.composed_type1.updated_at) == '2021-07-29T03:07:25+00:00'
 
     def test_parse_union_type_complex_property2(self):
         json_string = '{"@odata.type": "#microsoft.graph.User2", "id": 43,\


### PR DESCRIPTION
Switch from `dateutil` to more popular `pendulum` package for correct handling of `datetime` strings. It provides classes that are drop-in replacements for the native ones (they inherit from them).

Fixes #178 