### PR TITLE
Trigger publishing only on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: Publish package to PyPI and create release
 
 on:
   push:
-    branches: [main]
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 


### PR DESCRIPTION
## Overview

Updates publish workflow to only trigger publishing on tags push