### PR TITLE
Fix Enum serialization Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2024-04-09
+
+### Added
+
+### Changed
+- Enhanced error handling: Enabled silent failure when an enum key is not available
+
 ## [1.1.0] - 2024-02-29
 
 ### Added

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '1.1.0'
+VERSION: str = '1.2.0'

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -198,7 +198,7 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         try:
             return enum_class[camel_case_key]  # type: ignore
         except KeyError:
-            raise Exception(f'Invalid key: {camel_case_key} for enum {enum_class}.')
+            return None
 
     def get_object_value(self, factory: ParsableFactory) -> U:
         """Gets the model object value of the node

--- a/tests/unit/test_json_parse_node.py
+++ b/tests/unit/test_json_parse_node.py
@@ -99,6 +99,12 @@ def test_get_enum_value():
     assert result == OfficeLocation.Dunhill
 
 
+def test_get_enum_value_for_key_not_found():
+    parse_node = JsonParseNode("whitehouse")
+    result = parse_node.get_enum_value(OfficeLocation)
+    assert result is None
+
+
 def test_get_object_value(user1_json):
     parse_node = JsonParseNode(json.loads(user1_json))
     result = parse_node.get_object_value(User)
@@ -110,18 +116,23 @@ def test_get_object_value(user1_json):
     assert result.business_phones == ["+1 205 555 0108"]
     assert result.is_active is True
     assert result.mobile_phone is None
-    assert result.additional_data["additional_data"]["@odata.context"] == "https://graph.microsoft.com/v1.0/$metadata#users/$entity"
+    assert result.additional_data["additional_data"][
+        "@odata.context"] == "https://graph.microsoft.com/v1.0/$metadata#users/$entity"
     assert result.additional_data["additional_data"]["manager"] == {
         "id": UUID('8f841f30-e6e3-439a-a812-ebd369559c36'),
-        "updated_at": DateTime(2022, 1, 27, 12, 59, 45, 596117, tzinfo=FixedTimezone(0, name="+00:00")),
-        "is_active": True}
+        "updated_at":
+        DateTime(2022, 1, 27, 12, 59, 45, 596117, tzinfo=FixedTimezone(0, name="+00:00")),
+        "is_active": True
+    }
     assert result.additional_data["additional_data"]["approvers"] == [
         {
-            "id": UUID('8f841f30-e6e3-439a-a812-ebd369559c36'),
-            "updated_at": DateTime(2022, 1, 27, 12, 59, 45, 596117, tzinfo=FixedTimezone(0, name="+00:00")),
-            "is_active": True
-        },
-        {
+            "id":
+            UUID('8f841f30-e6e3-439a-a812-ebd369559c36'),
+            "updated_at":
+            DateTime(2022, 1, 27, 12, 59, 45, 596117, tzinfo=FixedTimezone(0, name="+00:00")),
+            "is_active":
+            True
+        }, {
             "display_name": "John Doe",
             "age": 32
         }


### PR DESCRIPTION
Fixes  https://github.com/microsoftgraph/msgraph-sdk-python/issues/480
Fixes https://github.com/microsoftgraph/msgraph-sdk-python/issues/222
## Overview

Currently - serializing an enum throws a KeyError if the key is not found in the Enum mapping

## Related Issue

Fixes [this ](https://github.com/microsoftgraph/msgraph-beta-sdk-python/issues/162)and  relates to [this](https://github.com/microsoft/kiota-serialization-json-dotnet/issues/202#issuecomment-2025928639)

### Demo
Before
![Value not available](https://github.com/microsoft/kiota-serialization-json-python/assets/23254784/cd251450-d2fc-43f9-86ab-76a8f542480c)

After
![after](https://github.com/microsoft/kiota-serialization-json-python/assets/23254784/e0dbd29a-222c-4903-ab68-72cc7d43392e)

