### PR TITLE
Revert "Bump docutils from 0.20.1 to 0.21.1"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ coverage[toml]==7.4.4
 
 dill==0.3.8
 
-docutils==0.21.1
+docutils==0.20.1
 
 flit==3.9.0
 


### PR DESCRIPTION
Reverts microsoft/kiota-serialization-json-python#268 since that version of doc utils is not compatible with python 3.8