### PR TITLE
Adding dict[str, Any] support

### DIFF
--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -203,7 +203,7 @@ class JsonSerializationWriter(SerializationWriter):
         if isinstance(values, list):
             result = []
             for val in values:
-                temp_writer = self._create_new_writer()
+                temp_writer: JsonSerializationWriter = self._create_new_writer()
                 temp_writer.write_any_value(None, val)
                 result.append(temp_writer.value)
 
@@ -246,6 +246,26 @@ class JsonSerializationWriter(SerializationWriter):
             for val in values:
                 temp_writer = self._create_new_writer()
                 temp_writer.write_enum_value(None, val)
+                result.append(temp_writer.value)
+
+            if key:
+                self.writer[key] = result
+            else:
+                self.value = result
+
+    def write_collection_of_dict_values(
+        self, key: Optional[str], values: Optional[List[Dict[str, Any]]]
+    ) -> None:
+        """Writes the specified collection of dictionary values to the stream with an optional given key.
+        Args:
+            key (Optional[str]): The key to be used for the written value. May be null.
+            values (Optional[List[Dict[str, Any]]]): The collection of dictionary values to be written.
+        """
+        if isinstance(values, list):
+            result = []
+            for val in values:
+                temp_writer: JsonSerializationWriter = self._create_new_writer()
+                temp_writer.write_dict_value(None, val)
                 result.append(temp_writer.value)
 
             if key:
@@ -319,6 +339,21 @@ class JsonSerializationWriter(SerializationWriter):
             self.writer[key] = None
         else:
             self.value = "null"
+
+    def write_dict_value(self, key: Optional[str], value: Dict[str, Any]) -> None:
+        """Writes the specified dictionary value to the stream with an optional given key.
+        Args:
+            key (Optional[str]): The key to be used for the written value. May be null.
+            value (Dict[str, Any]): The dictionary value to be written.
+        """
+        if isinstance(value, dict):
+            temp_writer: JsonSerializationWriter = self._create_new_writer()
+            for dict_key, dict_value in value.items():
+                temp_writer.write_any_value(dict_key, dict_value)
+            if key:
+                self.writer[key] = temp_writer.writer
+            else:
+                self.value = temp_writer.writer
 
     def write_additional_data_value(self, value: Dict[str, Any]) -> None:
         """Writes the specified additional data to the stream.
@@ -440,11 +475,15 @@ class JsonSerializationWriter(SerializationWriter):
                 self.write_collection_of_enum_values(key, value)
             elif all((type(x) in PRIMITIVE_TYPES) for x in value):
                 self.write_collection_of_primitive_values(key, value)
+            elif all(isinstance(x, dict) for x in value):
+                self.write_collection_of_dict_values(key, value)
             else:
                 raise TypeError(
                     f"Encountered an unknown collection type during serialization \
                     {value_type} with key {key}"
                 )
+        elif isinstance(value, dict):
+            self.write_dict_value(key, value)
         elif hasattr(value, '__dict__'):
             self.write_non_parsable_object_value(key, value)
         else:


### PR DESCRIPTION
## Overview

Several classes contain `dict[str, Any]` or even `list[dict[str, Any]]` inside their `additional_data` which is currently not handled.

## Related Issue

~

### Demo

~

### Notes

As I'm unsure about certain design decision this might not be the intended way of solving this.
Since I only tested this in the cases where it affects me it might not cover all cases.

## Testing Instructions

* Serialise and deserialise `CanvasLayout` which contains both `dict[str, Any]` and `list[dict[str, Any]]` and compare to the original object.