### PR TITLE
Fix data loss with 'None' being returned in cases where an integer is returned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug where date time deserialization would fail because of empty strings.
+- Fixed a bug where float deserialization if the number represented qualified as an int.
 
 ## [1.2.0] - 2024-04-09
 

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -67,9 +67,9 @@ class JsonParseNode(ParseNode, Generic[T, U]):
     def get_float_value(self) -> Optional[float]:
         """Gets the float value of the json node
         Returns:
-            float: The integer value of the node
+            float: The number value of the node
         """
-        return self._json_node if isinstance(self._json_node, float) else None
+        return float(self._json_node) if isinstance(self._json_node, (float, int)) else None
 
     def get_uuid_value(self) -> Optional[UUID]:
         """Gets the UUID value of the json node

--- a/tests/unit/test_json_parse_node.py
+++ b/tests/unit/test_json_parse_node.py
@@ -28,11 +28,31 @@ def test_get_bool_value():
     assert result is False
 
 
-def test_get_float_value():
+def test_get_float_value_from_float():
+    """
+    This test is to ensure that the get_float_value method returns a float when the value is a float
+    """
     parse_node = JsonParseNode(44.6)
     result = parse_node.get_float_value()
+    assert isinstance(result, float)
     assert result == 44.6
 
+
+@pytest.mark.parametrize("value", [0, 10, 100])
+def test_get_float_value(value: int):
+    """
+    Consider an OpenAPI Specification using the type: number and format: float or double    
+    Note: The OpenAPI Specification also allows for the use of the type: integer and format: int32 or int64
+
+    Consider an API with Price data [0, 0.5, 1, 1.5, 2] and so on
+    In this case, the contract must define the type as a number, with a hint of float or double as the format
+
+    Kiota should be able to parse the response as a float, even if the value is an integer, because it's still a number.
+    """
+    parse_node = JsonParseNode(value)
+    result = parse_node.get_float_value()
+    assert isinstance(result, float)
+    assert result == float(value)
 
 def test_get_uuid_value():
     parse_node = JsonParseNode("f58411c7-ae78-4d3c-bb0d-3f24d948de41")


### PR DESCRIPTION
Fix data loss with 'None' being returned in cases where a JSON Parse node that contains a 'number' that is not a true 'floating point number', but is an integer value.

Signed-off-by: Patrick Magee <patrick.magee@lexisnexisrisk.com>


## Overview

The OpenAPI Specification allows two types for numbers:

'number' and 'integer'. These can be further described in the specification with an optional format field ('-', 'float', 'double') for type number. and ('int32', 'int64') for type 'integer'.

If an API is returning pricing data, for an example, it likely will not describe this as a type 'integer' as we'll mostly be dealing with decimals. However, a Price can be a complete whole integer too. In this case, the 'number' type with a described format of 'float' or 'double' is still valid, it does not mean every value will not be an integer, an integer is still a valid number type.

## Related Issue

Fixes #331 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output