### PR TITLE
fix: get_datetime_value fails to serialize empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.0] - 2024-07-26
 
 ### Added
+
 - Support `dict[str, Any]` and `list[dict[str, Any]]` when writing additional data.
 
 ### Changed
+
+- Fixed a bug where date time deserialization would fail because of empty strings.
 
 ## [1.2.0] - 2024-04-09
 

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -89,7 +89,11 @@ class JsonParseNode(ParseNode, Generic[T, U]):
         """
         if isinstance(self._json_node, datetime):
             return self._json_node
+
         if isinstance(self._json_node, str):
+            if len(self._json_node) < 10:
+                return None
+
             datetime_obj = pendulum.parse(self._json_node, exact=True)
             if isinstance(datetime_obj, pendulum.DateTime):
                 return datetime_obj

--- a/tests/unit/test_json_parse_node.py
+++ b/tests/unit/test_json_parse_node.py
@@ -39,6 +39,11 @@ def test_get_uuid_value():
     result = parse_node.get_uuid_value()
     assert result == UUID("f58411c7-ae78-4d3c-bb0d-3f24d948de41")
 
+@pytest.mark.parametrize("value", ["", " ", "  ", "2022-01-0"])
+def test_get_datetime_value_returns_none_with_invalid_str(value: str):
+    parse_node = JsonParseNode(value)
+    result = parse_node.get_datetime_value()
+    assert result is None
 
 def test_get_datetime_value():
     parse_node = JsonParseNode('2022-01-27T12:59:45.596117')


### PR DESCRIPTION
In the ISO 8601 date format (YYYY-MM-DD), the shortest possible valid date string is 10 characters long. Therefore, if the length of the string is less than 10, it cannot be a valid date in this format, and the function can immediately return None without attempting to parse the date, which would be a more expensive operation.

## Overview

Brief description of what this PR does, and why it is needed.

## Related Issue

Fixes #258 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output