### PR TITLE
Fix Numeric strings being converted to Datetime objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.4.0] - 2024-08-23
+
+### Added
+
+- Fixed 4-digit numeric strings from being parsed as Datetime objects to being parsed as strings.
+
+
 ## [1.3.0] - 2024-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.4.0] - 2024-08-23
+## [1.3.1] - 2024-08-23
 
 ### Added
 

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '1.3.0'
+VERSION: str = '1.4.0'

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '1.4.0'
+VERSION: str = '1.3.1'

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -8,6 +8,8 @@ from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 from uuid import UUID
 
 import pendulum
+import re
+
 from kiota_abstractions.serialization import Parsable, ParsableFactory, ParseNode
 
 T = TypeVar("T")
@@ -286,6 +288,10 @@ class JsonParseNode(ParseNode, Generic[T, U]):
                     f"Found additional property {field_name} to \
                     deserialize but the model doesn't support additional data"
                 )
+
+    def is_four_digit_number(self, value: str) -> bool:
+        pattern = r'^\d{4}$'
+        return bool(re.match(pattern, value))
 
     def try_get_anything(self, value: Any) -> Any:
         if isinstance(value, (int, float, bool)) or value is None:

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -305,11 +305,11 @@ class JsonParseNode(ParseNode, Generic[T, U]):
                 if self.is_four_digit_number(value):
                     print(value)
                     return value
-                else:
-                    datetime_obj = pendulum.parse(value)
-                    if isinstance(datetime_obj, pendulum.Duration):
-                        return datetime_obj.as_timedelta()
-                    return datetime_obj
+
+                datetime_obj = pendulum.parse(value)
+                if isinstance(datetime_obj, pendulum.Duration):
+                    return datetime_obj.as_timedelta()
+                return datetime_obj
             except ValueError:
                 pass
             try:

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -309,12 +309,12 @@ class JsonParseNode(ParseNode, Generic[T, U]):
                 if self.is_four_digit_number(value):
                     print(value)
                     return value
-                else:
-                    datetime_obj = pendulum.parse(value)
-                    if isinstance(datetime_obj, pendulum.Duration):
-                        return datetime_obj.as_timedelta()
-                    return datetime_obj
-            except:
+
+                datetime_obj = pendulum.parse(value)
+                if isinstance(datetime_obj, pendulum.Duration):
+                    return datetime_obj.as_timedelta()
+                return datetime_obj
+            except ValueError:
                 pass
             try:
                 return UUID(value)

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -302,10 +302,14 @@ class JsonParseNode(ParseNode, Generic[T, U]):
             return dict(map(lambda x: (x[0], self.try_get_anything(x[1])), value.items()))
         if isinstance(value, str):
             try:
-                datetime_obj = pendulum.parse(value)
-                if isinstance(datetime_obj, pendulum.Duration):
-                    return datetime_obj.as_timedelta()
-                return datetime_obj
+                if self.is_four_digit_number(value):
+                    print(value)
+                    return value
+                else:
+                    datetime_obj = pendulum.parse(value)
+                    if isinstance(datetime_obj, pendulum.Duration):
+                        return datetime_obj.as_timedelta()
+                    return datetime_obj
             except ValueError:
                 pass
             try:

--- a/tests/unit/test_json_parse_node.py
+++ b/tests/unit/test_json_parse_node.py
@@ -1,6 +1,7 @@
 import json
 from datetime import date, datetime, time, timedelta
 from uuid import UUID
+import pendulum
 
 import pytest
 from pendulum import DateTime, FixedTimezone
@@ -54,16 +55,19 @@ def test_get_float_value(value: int):
     assert isinstance(result, float)
     assert result == float(value)
 
+
 def test_get_uuid_value():
     parse_node = JsonParseNode("f58411c7-ae78-4d3c-bb0d-3f24d948de41")
     result = parse_node.get_uuid_value()
     assert result == UUID("f58411c7-ae78-4d3c-bb0d-3f24d948de41")
+
 
 @pytest.mark.parametrize("value", ["", " ", "  ", "2022-01-0"])
 def test_get_datetime_value_returns_none_with_invalid_str(value: str):
     parse_node = JsonParseNode(value)
     result = parse_node.get_datetime_value()
     assert result is None
+
 
 def test_get_datetime_value():
     parse_node = JsonParseNode('2022-01-27T12:59:45.596117')
@@ -128,6 +132,20 @@ def test_get_enum_value_for_key_not_found():
     parse_node = JsonParseNode("whitehouse")
     result = parse_node.get_enum_value(OfficeLocation)
     assert result is None
+
+
+def test_get_anythin_does_not_convert_numeric_chars_to_datetime():
+    parse_node = JsonParseNode("1212")
+    result = parse_node.try_get_anything("1212")
+    assert isinstance(result, str)
+    assert result == "1212"
+
+
+def test_get_anythin_does_convert_date_string_to_datetime():
+    parse_node = JsonParseNode("2023-10-05T14:48:00.000Z")
+    result = parse_node.try_get_anything("2023-10-05T14:48:00.000Z")
+    assert isinstance(result, pendulum.DateTime)
+    assert result == pendulum.parse("2023-10-05T14:48:00.000Z")
 
 
 def test_get_object_value(user1_json):


### PR DESCRIPTION

Fixes https://github.com/microsoftgraph/msgraph-sdk-python/issues/653

## Overview

The PR fixes a problem where pendulum assumes all 4-digit numeric strings are Datetimes, e. 1212, 1214, 2530, 9057

Fixes # https://github.com/microsoftgraph/msgraph-sdk-python/issues/653

## Demo
### The Script below,
```python
async def get_my_messages():
    try:

        result = await user_client.sites.by_site_id(
            "yygbp.sharepoint.com,ab839da2-a22d-4e5c-bbeb-5060fad36e50,5cfc6d41-e5f6-4341-93fb-98728649efde"
        ).lists.by_list_id('6c8b411a-e440-4b24-9ee3-bfd3f06a9b4e'
                           ).items.by_list_item_id('1').get()
        print(f"sharepont list item id {result.id}")
        print(f"sharepoint list item fields {result.fields}")
        print(
            f"sharepoint list item text field {result.fields.additional_data['Doc_id']}"
        )
```
###  Output before
```
sharepoint list item fields FieldValueSet(additional_data={'@odata.etag': '"0f11e7ca-3f0e-46ce-b7e7-f2dfffe373da,2"', 'Title': 'Composition', 'LinkTitle': 'Composition', 'Doc_id': DateTime(1212, 1, 1, 0, 0, 0, tzinfo=Timezone('UTC')), 'Doc_numner': 1212.0, 'ContentType': 'Item', 'Modified': DateTime(2024, 8, 23, 14, 54, 17, tzinfo=Timezone('UTC')), 'Created': DateTime(2024, 8, 23, 14, 54, 17, tzinfo=Timezone('UTC')), 'AuthorLookupId': '9', 'EditorLookupId': '9', '_UIVersionString': '2.0', 'Attachments': True, 'Edit': '', 'LinkTitleNoMenu': 'Composition', 'ItemChildCount': '0', 'FolderChildCount': '0', '_ComplianceFlags': '', '_ComplianceTag': '', '_ComplianceTagWrittenTime': '', '_ComplianceTagUserId': ''}, id='1', odata_type=None)
sharepoint list item text field 1212-01-01 00:00:00+00:00

```
### Output After 
```
sharepoint list item fields FieldValueSet(additional_data={'@odata.etag': '"0f11e7ca-3f0e-46ce-b7e7-f2dfffe373da,2"', 'Title': 'Composition', 'LinkTitle': 'Composition', 'Doc_id': '1212', 'Doc_numner': 1212.0, 'ContentType': 'Item', 'Modified': DateTime(2024, 8, 23, 14, 54, 17, tzinfo=Timezone('UTC')), 'Created': DateTime(2024, 8, 23, 14, 54, 17, tzinfo=Timezone('UTC')), 'AuthorLookupId': '9', 'EditorLookupId': '9', '_UIVersionString': '2.0', 'Attachments': True, 'Edit': '', 'LinkTitleNoMenu': 'Composition', 'ItemChildCount': '0', 'FolderChildCount': '0', '_ComplianceFlags': '', '_ComplianceTag': '', '_ComplianceTagWrittenTime': '', '_ComplianceTagUserId': ''}, id='1', odata_type=None)
sharepoint list item text field 1212
```
### Notes

This change could be reverted  if pendulum does an update that fixes the bug.
## Testing Instructions
