### PR TITLE
Fix numeric strings parsed as datetime objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2024-09-10
+
+### Added
+
+- Fixed  numeric strings from being parsed as Datetime objects to being parsed as strings.
+-Only parse to Datetime objects that conform to ISO 8601 format.
+
+
 
 ## [1.3.1] - 2024-08-23
 

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '1.3.1'
+VERSION: str = '1.3.2'

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -293,10 +293,6 @@ class JsonParseNode(ParseNode, Generic[T, U]):
                     deserialize but the model doesn't support additional data"
                 )
 
-    def __is_four_digit_number(self, value: str) -> bool:
-        pattern = r'^\d{4}$'
-        return bool(re.match(pattern, value))
-
     def try_get_anything(self, value: Any) -> Any:
         if isinstance(value, (int, float, bool)) or value is None:
             return value
@@ -306,8 +302,6 @@ class JsonParseNode(ParseNode, Generic[T, U]):
             return dict(map(lambda x: (x[0], self.try_get_anything(x[1])), value.items()))
         if isinstance(value, str):
             try:
-                if self.__is_four_digit_number(value):
-                    return value
 
                 datetime_obj = pendulum.parse(value)
                 if isinstance(datetime_obj, pendulum.Duration):

--- a/kiota_serialization_json/json_parse_node.py
+++ b/kiota_serialization_json/json_parse_node.py
@@ -302,7 +302,8 @@ class JsonParseNode(ParseNode, Generic[T, U]):
             return dict(map(lambda x: (x[0], self.try_get_anything(x[1])), value.items()))
         if isinstance(value, str):
             try:
-
+                if value.isdigit():
+                    return value
                 datetime_obj = pendulum.parse(value)
                 if isinstance(datetime_obj, pendulum.Duration):
                     return datetime_obj.as_timedelta()

--- a/tests/unit/test_json_parse_node.py
+++ b/tests/unit/test_json_parse_node.py
@@ -141,6 +141,25 @@ def test_get_anythin_does_not_convert_numeric_chars_to_datetime():
     assert result == "1212"
 
 
+def test_get_anythin_does_not_convert_any_length_numeric_chars_to_datetime():
+    parse_node = JsonParseNode("1212")
+    result1 = parse_node.try_get_anything("1212")
+    parse_node_two = JsonParseNode("-PT15M")
+    result2 = parse_node_two.try_get_anything("-PT15M")
+    parse_node_three = JsonParseNode("20081008")
+    result3 = parse_node_three.try_get_anything("20081008")
+    parse_node_four = JsonParseNode("1011317")
+    result4 = parse_node_four.try_get_anything("1011317")
+    assert isinstance(result1, str)
+    assert result1 == "1212"
+    assert isinstance(result2, str)
+    assert result2 == "-PT15M"
+    assert isinstance(result3, str)
+    assert result3 == "20081008"
+    assert isinstance(result4, str)
+    assert result4 == "1011317"
+
+
 def test_get_anythin_does_convert_date_string_to_datetime():
     parse_node = JsonParseNode("2023-10-05T14:48:00.000Z")
     result = parse_node.try_get_anything("2023-10-05T14:48:00.000Z")


### PR DESCRIPTION
## Overview

From my research, ms Graph works with datetime objects that conform to ISO 8601 format such as:

- "2024-09-10"
- "2024-09-10 12:34:56"
- "2024-08-18T05:26:14Z"
These can be isolated using isdigit which is a string method as they contain characters such as -, /, : that are not string avlues

## Related Issue

Fixes https://github.com/microsoftgraph/msgraph-sdk-python/issues/881

### Demo
Test values
```python
test_values = [
    "2008-10-08T18:30:00.000000Z", "2008-10-08T18:30:00.000000", "20081008",
    "-PT15M", "1011317", "1150144"
]
```

Parsed VALUES
```
2008-10-08 18:30:00+00:00
2008-10-08 18:30:00+00:00
20081008
-PT15M
1011317
1150144

```
