### PR TITLE
fix serialization of pendulum.DateTime objects in JsonSerializationWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.3] - 2024-10-03
+
+### Fixed
+
+- Fixed an issue where `pendulum.DateTime` objects were not properly serialized by `JsonSerializationWriter`. Now, `pendulum.DateTime` objects are correctly recognized as subclasses of `datetime.datetime` and serialized accordingly.
 
 ## [1.3.2] - 2024-09-10
 
 ### Added
 
-- Fixed  numeric strings from being parsed as Datetime objects to being parsed as strings.
--Only parse to Datetime objects that conform to ISO 8601 format.
-
-
+- Fixed numeric strings from being parsed as Datetime objects to being parsed as strings.
+- Only parse to Datetime objects that conform to ISO 8601 format.
 
 ## [1.3.1] - 2024-08-23
 
 ### Added
 
 - Fixed 4-digit numeric strings from being parsed as Datetime objects to being parsed as strings.
-
 
 ## [1.3.0] - 2024-07-26
 
@@ -37,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Enhanced error handling: Enabled silent failure when an enum key is not available
 
 ## [1.1.0] - 2024-02-29
@@ -44,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Support objects and collections when writing additional data.
 
 ## [1.0.1] - 2023-12-16
@@ -51,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Bump pendulum to v3.0.0b1 for python 3.12 support.
 
 ## [1.0.0] - 2023-10-31
@@ -58,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - GA release
 
 ## [0.4.2] - 2023-10-11
@@ -65,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Switched from python-dateutil to pendulum for parsing datetime types.
 
 ## [0.4.1] - 2023-09-21
@@ -72,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Allow passing of valid strings as values for datetime and UUID fields.
 
 ## [0.4.0] - 2023-07-27
@@ -79,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Enabled backing store support
 
 ## [0.3.7] - 2023-07-04
@@ -86,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fixes the key assignment to the writer in write_bytes_value.
 
 ## [0.3.6] - 2023-06-27
@@ -93,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fixed a bug with loading json response in method to get root parse node.
 
 ## [0.3.5] - 2023-06-14
@@ -153,4 +165,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug with deserializing 'None' string values in enums.
-

--- a/kiota_serialization_json/_version.py
+++ b/kiota_serialization_json/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '1.3.2'
+VERSION: str = '1.3.3'

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -480,7 +480,8 @@ class JsonSerializationWriter(SerializationWriter):
                 self.__write_collection_of_dict_values(key, value)
             else:
                 raise TypeError(
-                    f"Encountered an unknown collection type during serialization {type(value)} with key {key}"
+                    f"Encountered an unknown collection type during serialization {type(value)} \
+                    with key {key}"
                 )
         elif isinstance(value, dict):
             self.__write_dict_value(key, value)

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -191,7 +191,7 @@ class JsonSerializationWriter(SerializationWriter):
                 raise ValueError("Invalid time string value found")
 
     def write_collection_of_primitive_values(
-            self, key: Optional[str], values: Optional[List[T]]
+        self, key: Optional[str], values: Optional[List[T]]
     ) -> None:
         """Writes the specified collection of primitive values to the stream with an optional
         given key.
@@ -212,7 +212,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = result
 
     def write_collection_of_object_values(
-            self, key: Optional[str], values: Optional[List[U]]
+        self, key: Optional[str], values: Optional[List[U]]
     ) -> None:
         """Writes the specified collection of model objects to the stream with an optional
         given key.
@@ -233,7 +233,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = obj_list
 
     def write_collection_of_enum_values(
-            self, key: Optional[str], values: Optional[List[Enum]]
+        self, key: Optional[str], values: Optional[List[Enum]]
     ) -> None:
         """Writes the specified collection of enum values to the stream with an optional given key.
         Args:
@@ -253,7 +253,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = result
 
     def __write_collection_of_dict_values(
-            self, key: Optional[str], values: Optional[List[Dict[str, Any]]]
+        self, key: Optional[str], values: Optional[List[Dict[str, Any]]]
     ) -> None:
         """Writes the specified collection of dictionary values to the stream with an optional
             given key.
@@ -290,7 +290,7 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = base64_string
 
     def write_object_value(
-            self, key: Optional[str], value: Optional[U], *additional_values_to_merge: U
+        self, key: Optional[str], value: Optional[U], *additional_values_to_merge: U
     ) -> None:
         """Writes the specified model object to the stream with an optional given key.
         Args:
@@ -423,7 +423,7 @@ class JsonSerializationWriter(SerializationWriter):
 
     @property
     def on_start_object_serialization(
-            self
+        self
     ) -> Optional[Callable[[Parsable, SerializationWriter], None]]:
         """Gets the callback called right after the serialization process starts.
         Returns:
@@ -434,7 +434,7 @@ class JsonSerializationWriter(SerializationWriter):
 
     @on_start_object_serialization.setter
     def on_start_object_serialization(
-            self, value: Optional[Callable[[Parsable, SerializationWriter], None]]
+        self, value: Optional[Callable[[Parsable, SerializationWriter], None]]
     ) -> None:
         """Sets the callback called right after the serialization process starts.
         Args:

--- a/kiota_serialization_json/json_serialization_writer.py
+++ b/kiota_serialization_json/json_serialization_writer.py
@@ -23,7 +23,7 @@ class JsonSerializationWriter(SerializationWriter):
         self.value: Any = None
 
         self._on_start_object_serialization: Optional[Callable[[Parsable, SerializationWriter],
-        None]] = None
+                                                               None]] = None
         self._on_before_object_serialization: Optional[Callable[[Parsable], None]] = None
         self._on_after_object_serialization: Optional[Callable[[Parsable], None]] = None
 
@@ -79,7 +79,7 @@ class JsonSerializationWriter(SerializationWriter):
         """Writes the specified uuid value to the stream with an optional given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            value (Optional[UUId]): The uuid value to be written.
+            value (Optional[UUID]): The uuid value to be written.
         """
         if isinstance(value, UUID):
             if key:
@@ -106,9 +106,9 @@ class JsonSerializationWriter(SerializationWriter):
         """
         if isinstance(value, datetime):
             if key:
-                self.writer[key] = str(value.isoformat())
+                self.writer[key] = value.isoformat()
             else:
-                self.value = str(value.isoformat())
+                self.value = value.isoformat()
         elif isinstance(value, str):
             try:
                 pendulum.parse(value)
@@ -238,7 +238,7 @@ class JsonSerializationWriter(SerializationWriter):
         """Writes the specified collection of enum values to the stream with an optional given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values Optional[List[Enum]): The enum values to be written.
+            values (Optional[List[Enum]]): The enum values to be written.
         """
         if isinstance(values, list):
             result = []
@@ -359,7 +359,7 @@ class JsonSerializationWriter(SerializationWriter):
     def write_additional_data_value(self, value: Dict[str, Any]) -> None:
         """Writes the specified additional data to the stream.
         Args:
-            value (Dict[str, Any]): he additional data to be written.
+            value (Dict[str, Any]): The additional data to be written.
         """
         if isinstance(value, dict):
             for key, val in value.items():
@@ -389,17 +389,17 @@ class JsonSerializationWriter(SerializationWriter):
     def on_before_object_serialization(self) -> Optional[Callable[[Parsable], None]]:
         """Gets the callback called before the object gets serialized.
         Returns:
-            Optional[Callable[[Parsable], None]]:the callback called before the object
+            Optional[Callable[[Parsable], None]]: The callback called before the object
             gets serialized.
         """
         return self._on_before_object_serialization
 
     @on_before_object_serialization.setter
     def on_before_object_serialization(self, value: Optional[Callable[[Parsable], None]]) -> None:
-        """Sets the callback called before the objects gets serialized.
+        """Sets the callback called before the objects get serialized.
         Args:
-            value (Optional[Callable[[Parsable], None]]): the callback called before the objects
-            gets serialized.
+            value (Optional[Callable[[Parsable], None]]): The callback called before the objects
+            get serialized.
         """
         self._on_before_object_serialization = value
 
@@ -407,17 +407,17 @@ class JsonSerializationWriter(SerializationWriter):
     def on_after_object_serialization(self) -> Optional[Callable[[Parsable], None]]:
         """Gets the callback called after the object gets serialized.
         Returns:
-            Optional[Optional[Callable[[Parsable], None]]]: the callback called after the object
+            Optional[Callable[[Parsable], None]]: The callback called after the object
             gets serialized.
         """
         return self._on_after_object_serialization
 
     @on_after_object_serialization.setter
     def on_after_object_serialization(self, value: Optional[Callable[[Parsable], None]]) -> None:
-        """Sets the callback called after the objects gets serialized.
+        """Sets the callback called after the objects get serialized.
         Args:
-            value (Optional[Callable[[Parsable], None]]): the callback called after the objects
-            gets serialized.
+            value (Optional[Callable[[Parsable], None]]): The callback called after the objects
+            get serialized.
         """
         self._on_after_object_serialization = value
 
@@ -427,7 +427,7 @@ class JsonSerializationWriter(SerializationWriter):
     ) -> Optional[Callable[[Parsable, SerializationWriter], None]]:
         """Gets the callback called right after the serialization process starts.
         Returns:
-            Optional[Callable[[Parsable, SerializationWriter], None]]: the callback called
+            Optional[Callable[[Parsable, SerializationWriter], None]]: The callback called
             right after the serialization process starts.
         """
         return self._on_start_object_serialization
@@ -438,7 +438,7 @@ class JsonSerializationWriter(SerializationWriter):
     ) -> None:
         """Sets the callback called right after the serialization process starts.
         Args:
-            value (Optional[Callable[[Parsable, SerializationWriter], None]]): the callback
+            value (Optional[Callable[[Parsable, SerializationWriter], None]]): The callback
             called right after the serialization process starts.
         """
         self._on_start_object_serialization = value
@@ -471,7 +471,10 @@ class JsonSerializationWriter(SerializationWriter):
                 self.write_collection_of_object_values(key, value)
             elif all(isinstance(x, Enum) for x in value):
                 self.write_collection_of_enum_values(key, value)
-            elif all(any(isinstance(x, primitive_type) for primitive_type in PRIMITIVE_TYPES) for x in value):
+            elif all(
+                any(isinstance(x, primitive_type) for primitive_type in PRIMITIVE_TYPES)
+                for x in value
+            ):
                 self.write_collection_of_primitive_values(key, value)
             elif all(isinstance(x, dict) for x in value):
                 self.__write_collection_of_dict_values(key, value)

--- a/tests/unit/test_json_parse_node_factory.py
+++ b/tests/unit/test_json_parse_node_factory.py
@@ -18,7 +18,7 @@ def test_get_root_parse_node(sample_json_string):
     assert isinstance(root, JsonParseNode)
     assert root._json_node == json.loads(sample_json_string)
 
-  
+
 def test_get_root_parse_node_no_content_type(sample_json_string):
     with pytest.raises(Exception) as e_info:
         factory = JsonParseNodeFactory()

--- a/tests/unit/test_json_serialization_writer.py
+++ b/tests/unit/test_json_serialization_writer.py
@@ -2,7 +2,6 @@ from datetime import date
 from uuid import UUID
 
 import pytest
-
 import pendulum
 from kiota_serialization_json.json_serialization_writer import JsonSerializationWriter
 
@@ -72,20 +71,23 @@ def test_write_uuid_value():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"id": "8f841f30-e6e3-439a-a812-ebd369559c36"}'
-    
+
+
 def test_write_uuid_value_with_valid_string():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_uuid_value("id", "8f841f30-e6e3-439a-a812-ebd369559c36")
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"id": "8f841f30-e6e3-439a-a812-ebd369559c36"}'
-    
+
+
 def test_write_uuid_value_with_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
         json_serialization_writer.write_uuid_value("id", "invalid-uuid-string")
     assert "Invalid UUID string value found for property id" in str(excinfo.value)
-    
+
+
 def test_write_datetime_value():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_datetime_value(
@@ -94,7 +96,8 @@ def test_write_datetime_value():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117+00:00"}'
-    
+
+
 def test_write_datetime_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_datetime_value(
@@ -103,8 +106,9 @@ def test_write_datetime_value_valid_string():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117+00:00"}'
-    
-def test_write_datetime_value_valid_string():
+
+
+def test_write_datetime_value_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
         json_serialization_writer.write_datetime_value(
@@ -112,16 +116,21 @@ def test_write_datetime_value_valid_string():
         )
     assert "Invalid datetime string value found for property updatedAt" in str(excinfo.value)
 
+
 def test_write_timedelta_value():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_timedelta_value(
         "diff",
-        (pendulum.parse('2022-01-27T12:59:45.596117') - pendulum.parse('2022-01-27T10:59:45.596117')).as_timedelta()
+        (
+            pendulum.parse('2022-01-27T12:59:45.596117') -
+            pendulum.parse('2022-01-27T10:59:45.596117')
+        ).as_timedelta()
     )
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"diff": "2:00:00"}'
-    
+
+
 def test_write_timedelta_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_timedelta_value(
@@ -131,7 +140,8 @@ def test_write_timedelta_value_valid_string():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"diff": "2:00:00"}'
-    
+
+
 def test_write_timedelta_value_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
@@ -140,7 +150,7 @@ def test_write_timedelta_value_invalid_string():
             "invalid-timedelta-string"
         )
     assert "Invalid timedelta string value found for property diff" in str(excinfo.value)
-    
+
 
 def test_write_date_value():
     json_serialization_writer = JsonSerializationWriter()
@@ -149,18 +159,21 @@ def test_write_date_value():
     content_string = content.decode('utf-8')
     assert content_string == '{"birthday": "2000-09-04"}'
 
+
 def test_write_date_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_date_value("birthday", "2000-09-04")
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"birthday": "2000-09-04"}'
-    
+
+
 def test_write_date_value_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
         json_serialization_writer.write_date_value("birthday", "invalid-date-string")
     assert "Invalid date string value found for property birthday" in str(excinfo.value)
+
 
 def test_write_time_value():
     json_serialization_writer = JsonSerializationWriter()
@@ -172,6 +185,7 @@ def test_write_time_value():
     content_string = content.decode('utf-8')
     assert content_string == '{"time": "12:59:45.596117"}'
 
+
 def test_write_time_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_time_value(
@@ -181,7 +195,8 @@ def test_write_time_value_valid_string():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"time": "12:59:45.596117"}'
-    
+
+
 def test_write_time_value_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
@@ -190,6 +205,7 @@ def test_write_time_value_invalid_string():
             "invalid-time-string"
         )
     assert "Invalid time string value found for property time" in str(excinfo.value)
+
 
 def test_write_collection_of_primitive_values():
     json_serialization_writer = JsonSerializationWriter()
@@ -206,9 +222,14 @@ def test_write_collection_of_object_values(user_1, user_2):
     json_serialization_writer.write_collection_of_object_values("users", [user_1, user_2])
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
-    assert content_string == '{"users": [{"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
-        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '\
-        '{"display_name": "John Doe", "age": 32}]}'
+    expected = (
+        '{"users": ['
+        '{"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '
+        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '
+        '{"display_name": "John Doe", "age": 32}'
+        ']}'
+    )
+    assert content_string == expected
 
 
 def test_write_collection_of_enum_values():
@@ -226,8 +247,13 @@ def test_write_object_value(user_1):
     json_serialization_writer.write_object_value("user1", user_1)
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
-    assert content_string == '{"user1": {"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
-        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}}'
+    expected = (
+        '{"user1": {'
+        '"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '
+        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true'
+        '}}'
+    )
+    assert content_string == expected
 
 
 def test_write_enum_value():
@@ -265,14 +291,18 @@ def test_write_additional_data_value(user_1, user_2):
     )
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
-    assert content_string == '{"@odata.context": '\
-        '"https://graph.microsoft.com/v1.0/$metadata#users/$entity", '\
-            '"businessPhones": ["+1 205 555 0108"], '\
-            '"manager": {"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
-                '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '\
-            '"approvers": [{"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
-                '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '\
-                '{"display_name": "John Doe", "age": 32}], '\
-            '"created_at": "2022-01-27", '\
-            '"updated_at": "2024-09-24T00:00:00", '\
-            '"data": {"groups": [{"friends": [{"display_name": "John Doe", "age": 32}]}]}}'
+    expected = (
+        '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity", '
+        '"businessPhones": ["+1 205 555 0108"], '
+        '"manager": {"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '
+        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '
+        '"approvers": ['
+        '{"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '
+        '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '
+        '{"display_name": "John Doe", "age": 32}'
+        '], '
+        '"created_at": "2022-01-27", '
+        '"updated_at": "2024-09-24T00:00:00", '
+        '"data": {"groups": [{"friends": [{"display_name": "John Doe", "age": 32}]}]}}'
+    )
+    assert content_string == expected

--- a/tests/unit/test_json_serialization_writer.py
+++ b/tests/unit/test_json_serialization_writer.py
@@ -100,9 +100,7 @@ def test_write_datetime_value():
 
 def test_write_datetime_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
-    json_serialization_writer.write_datetime_value(
-        "updatedAt", "2022-01-27T12:59:45.596117"
-    )
+    json_serialization_writer.write_datetime_value("updatedAt", "2022-01-27T12:59:45.596117")
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117+00:00"}'
@@ -111,17 +109,14 @@ def test_write_datetime_value_valid_string():
 def test_write_datetime_value_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
-        json_serialization_writer.write_datetime_value(
-            "updatedAt", "invalid-datetime-string"
-        )
+        json_serialization_writer.write_datetime_value("updatedAt", "invalid-datetime-string")
     assert "Invalid datetime string value found for property updatedAt" in str(excinfo.value)
 
 
 def test_write_timedelta_value():
     json_serialization_writer = JsonSerializationWriter()
     json_serialization_writer.write_timedelta_value(
-        "diff",
-        (
+        "diff", (
             pendulum.parse('2022-01-27T12:59:45.596117') -
             pendulum.parse('2022-01-27T10:59:45.596117')
         ).as_timedelta()
@@ -133,10 +128,7 @@ def test_write_timedelta_value():
 
 def test_write_timedelta_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
-    json_serialization_writer.write_timedelta_value(
-        "diff",
-        "2:00:00"
-    )
+    json_serialization_writer.write_timedelta_value("diff", "2:00:00")
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"diff": "2:00:00"}'
@@ -145,10 +137,7 @@ def test_write_timedelta_value_valid_string():
 def test_write_timedelta_value_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
-        json_serialization_writer.write_timedelta_value(
-            "diff",
-            "invalid-timedelta-string"
-        )
+        json_serialization_writer.write_timedelta_value("diff", "invalid-timedelta-string")
     assert "Invalid timedelta string value found for property diff" in str(excinfo.value)
 
 
@@ -188,10 +177,7 @@ def test_write_time_value():
 
 def test_write_time_value_valid_string():
     json_serialization_writer = JsonSerializationWriter()
-    json_serialization_writer.write_time_value(
-        "time",
-        "12:59:45.596117"
-    )
+    json_serialization_writer.write_time_value("time", "12:59:45.596117")
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"time": "12:59:45.596117"}'
@@ -200,10 +186,7 @@ def test_write_time_value_valid_string():
 def test_write_time_value_invalid_string():
     with pytest.raises(ValueError) as excinfo:
         json_serialization_writer = JsonSerializationWriter()
-        json_serialization_writer.write_time_value(
-            "time",
-            "invalid-time-string"
-        )
+        json_serialization_writer.write_time_value("time", "invalid-time-string")
     assert "Invalid time string value found for property time" in str(excinfo.value)
 
 

--- a/tests/unit/test_json_serialization_writer.py
+++ b/tests/unit/test_json_serialization_writer.py
@@ -255,6 +255,7 @@ def test_write_additional_data_value(user_1, user_2):
             "manager": user_1,
             "approvers": [user_1, user_2],
             "created_at": date(2022, 1, 27),
+            "updated_at": pendulum.DateTime(2024, 9, 24),
             "data": {
                 "groups": [{
                     "friends": [user_2]
@@ -271,5 +272,7 @@ def test_write_additional_data_value(user_1, user_2):
                 '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '\
             '"approvers": [{"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
                 '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '\
-                '{"display_name": "John Doe", "age": 32}], "created_at": "2022-01-27", '\
-                '"data": {"groups": [{"friends": [{"display_name": "John Doe", "age": 32}]}]}}'
+                '{"display_name": "John Doe", "age": 32}], '\
+            '"created_at": "2022-01-27", '\
+            '"updated_at": "2024-09-24T00:00:00", '\
+            '"data": {"groups": [{"friends": [{"display_name": "John Doe", "age": 32}]}]}}'

--- a/tests/unit/test_json_serialization_writer.py
+++ b/tests/unit/test_json_serialization_writer.py
@@ -103,7 +103,7 @@ def test_write_datetime_value_valid_string():
     json_serialization_writer.write_datetime_value("updatedAt", "2022-01-27T12:59:45.596117")
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
-    assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117+00:00"}'
+    assert content_string == '{"updatedAt": "2022-01-27T12:59:45.596117"}'
 
 
 def test_write_datetime_value_invalid_string():


### PR DESCRIPTION
**Environment**
- Python Version: 3.11.7 
- kiota-serialization-json version: 1.3.2 
- OS: MacOS

**Describe the bug**
The `write_any_value` method in `JsonSerializationWriter` fails to properly handle `pendulum.DateTime` objects. This is due to insufficient type checking, which causes `pendulum.DateTime` objects to be treated as non-primitive types instead of as datetime objects. Specifically, the issue stems from not using `isinstance()` to check for datetime types, which prevents `pendulum.DateTime` from being recognized as a subclass of the primitive `datetime.datetime`.

**To Reproduce**
1. Create a `JsonSerializationWriter` instance
2. Attempt to serialize an object containing a `pendulum.DateTime` field (specifically as an `additional_data` `dict`)
3. Observe that the `pendulum.DateTime` object is not serialized correctly

**Expected behavior**
`pendulum.DateTime` objects should be treated as datetime objects and serialized correctly, just like `datetime.datetime` objects. The serialization process should recognize `pendulum.DateTime` as a subclass of `datetime.datetime` and handle it accordingly.

**Code to reproduce**
```python
from kiota_serialization_json import JsonSerializationWriter
import pendulum

writer = JsonSerializationWriter()
writer.write_additional_data_value({
    "created_at": pendulum.DateTime(2024, 9, 24)
})
content = writer.get_serialized_content()
print(content.decode('utf-8'))